### PR TITLE
Use less-likely-to-be-buggy Interchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ source/_cookbook/
 __pycache__/
 .pytest_cache
 .ipynb_checkpoints
+
+# macOS
+.DS_Store

--- a/devtools/conda-envs/examples_env.yml
+++ b/devtools/conda-envs/examples_env.yml
@@ -14,7 +14,7 @@ dependencies:
     - packaging
     # Examples
     - openff-toolkit-examples>=0.14.0
-    - openff-interchange>=0.3.7
+    - openff-interchange>=0.3.18
     - openff-nagl==0.2.2
     # - openff-fragmenter
     # - openff-qcsubmit
@@ -22,6 +22,6 @@ dependencies:
     - lammps
     - rich
     - jax
-    - dglteam/label/cu118::dgl
+    - dglteam/label/cu118::dgl  # This probably can be conda-forge ...
     - parmed<4
     - nglview>=3.0.6

--- a/source/_ext/cookbook/github.py
+++ b/source/_ext/cookbook/github.py
@@ -81,6 +81,10 @@ def get_tag_matching_installed_version(repo: str) -> str:
     if version in tagnames:
         return version
     else:
-        raise ValueError(
-            f"Could not find tag for version {version}; found tags {tagnames}"
-        )
+        if any([tag.startswith('v') for tag in tagnames]):
+            if f"v{version}" in tagnames:
+                return f"v{version}"
+
+    raise ValueError(
+            f"Could not find tag for version {version} or v{version}; found tags {tagnames}"
+    )

--- a/source/workshops/2024/smirnoff/colab-env.yml
+++ b/source/workshops/2024/smirnoff/colab-env.yml
@@ -1,4 +1,4 @@
-name: openff-docs-examples
+name: 2024-smirnoff-workshop
 channels:
     - conda-forge
 dependencies:

--- a/source/workshops/2024/smirnoff/env.yml
+++ b/source/workshops/2024/smirnoff/env.yml
@@ -1,4 +1,4 @@
-name: openff-docs-examples
+name: 2024-smirnoff-workshop
 channels:
     - conda-forge
 dependencies:


### PR DESCRIPTION
While checking workshop materials, I noticed the examples are rendered with an outdated constraint