### PR TITLE
Make ligand_in_water notebook optional

### DIFF
--- a/source/_ext/cookbook/globals_.py
+++ b/source/_ext/cookbook/globals_.py
@@ -94,6 +94,7 @@ be rendered if they're in a cache.
 OPTIONAL_NOTEBOOKS: list[str] = [
     # ".*/experimental/.*",
     "openforcefield/openff-interchange/experimental/openmmforcefields/gaff.ipynb",
+    "openforcefield/openff-interchange/ligand_in_water/ligand_in_water.ipynb",
 ]
 """
 Notebooks whose execution failure will not cause notebook processing to fail.


### PR DESCRIPTION
`openforcefield/openff-interchange/ligand_in_water/ligand_in_water.ipynb` is causing cookbook generation to fail, so we'll skip it if it fails until further notice.