### PR TITLE
Document status of x64 macOS support

### DIFF
--- a/source/install.md
+++ b/source/install.md
@@ -271,7 +271,7 @@ Note that this will affect how Conda behaves with other environments.
 
 ## OpenFF on Intel-based macOS (x86)
 
-All OpenFF software is written in pure Python code and can be expected to function long as the relevant dependencies can be installed. As of Fall 2024, some users have reported issues with versions of AmberTools on certain Intel-based macOS platforms. OpenFF tools, for use cases that require it, work as long as the AmberTools installation functions. For those with access to Apple Silicon hardware, we recommend using the native architecture (Apple Silicon/ARM/`osx-arm64`).
+All OpenFF software is written in pure Python code and can be expected to function long as the relevant dependencies can be installed. As of Q3 2024, some users have reported issues with versions of AmberTools on certain Intel-based macOS platforms. OpenFF tools, for use cases that require it, work as long as the AmberTools installation functions. For those with access to Apple Silicon hardware, we recommend using the native architecture (Apple Silicon/ARM/`osx-arm64`).
 
 Note that AmberTools can also be built locally from its own release tarball according to the [instructions Amber's website](https://ambermd.org/GetAmber.php#ambertools).
 

--- a/source/install.md
+++ b/source/install.md
@@ -268,3 +268,11 @@ Note that this will affect how Conda behaves with other environments.
 
 [Rosetta]: https://support.apple.com/en-au/HT211861
 [use Rosetta]: https://conda-forge.org/docs/user/tipsandtricks/#installing-apple-intel-packages-on-apple-silicon
+
+## OpenFF on Intel-based macOS (x86)
+
+All OpenFF software is written in pure Python code and can be expected to function long as the relevant dependencies can be installed. As of Fall 2024, some users have reported issues with versions of AmberTools on certain Intel-based macOS platforms. OpenFF tools, for use cases that require it, work as long as the AmberTools installation functions. For those with access to Apple Silicon hardware, we recommend using the native architecture (Apple Silicon/ARM/`osx-arm64`).
+
+Note that AmberTools can also be built locally from its own release tarball according to the [instructions Amber's website](https://ambermd.org/GetAmber.php#ambertools).
+
+Note also that many OpenFF use cases only require AmberTools for its AM1-BCC partial charge assignment; for users with [OpenEye Licenses](https://docs.eyesopen.com/applications/common/license.html), OpenEye Toolkits' OEChem module can be used instead.


### PR DESCRIPTION
Closes #78

- [x] Communicate that x64 macOS support is limited by upstreams
- [x] Give rough dates on AmberTools issues
- [x] Recommend `osx-arm64` when available
- [x] Mention building AmberTools from source
- [ ] ~~Mention NAGL as a replacement~~