### PR TITLE
Fix examples

### DIFF
--- a/devtools/conda-envs/examples_env.yml
+++ b/devtools/conda-envs/examples_env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python=3.11
+  - python
   - jupyterlab>=4
   - ipywidgets>=8
   # Cookbook
@@ -13,7 +13,7 @@ dependencies:
   - requests
   - packaging
   # Examples
-  - openff-toolkit-examples>=0.16.6
+  - openff-toolkit-examples>=0.16.8
   - openff-interchange ~=0.4.2
   - openff-nagl
   # - openff-fragmenter

--- a/devtools/conda-envs/examples_env.yml
+++ b/devtools/conda-envs/examples_env.yml
@@ -26,5 +26,8 @@ dependencies:
   - parmed
   - nglview ~=3.0.6
   - psi4
+  # openff-nagl optional training deps
+  - pyarrow
+  - dgl
   # torchdata.datapipes was removed in 0.10.0
   - torchdata<=0.9.0

--- a/devtools/conda-envs/examples_env.yml
+++ b/devtools/conda-envs/examples_env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python
+  - python=3.11
   - jupyterlab>=4
   - ipywidgets>=8
   # Cookbook

--- a/devtools/conda-envs/examples_env.yml
+++ b/devtools/conda-envs/examples_env.yml
@@ -29,5 +29,6 @@ dependencies:
   # openff-nagl optional training deps
   - pyarrow
   - dgl
+  - openff-recharge
   # torchdata.datapipes was removed in 0.10.0
   - torchdata<=0.9.0


### PR DESCRIPTION
Examples are broken because they pull Toolkit 0.16.7 and openff-units 0.3.0, which are not compatible. Failure mode is extremely unusual; the second Python invocation that calls `assign_partial_charges` in a new environment or with a fresh `~/.cache/pint` folder raises a cryptic error:

```
ToolkitWrapper around AmberTools version 23.6 <class 'openff.toolkit.utils.exceptions.IncompatibleUnitError'> : Unsupported unit passed to partial_charges setter. Found unit elementary_charge, expected elementary_charge
```